### PR TITLE
Remove rounding of utm values

### DIFF
--- a/lib/latlong/latlongToUtm.js
+++ b/lib/latlong/latlongToUtm.js
@@ -92,8 +92,8 @@
             utmNorthing += 10000000;
         }
 
-        utmcoords.easting = Math.round(utmEasting);
-        utmcoords.northing = Math.round(utmNorthing);
+        utmcoords.easting = utmEasting;
+        utmcoords.northing = utmNorthing;
         utmcoords.zoneNumber = zoneNumber;
         utmcoords.zoneLetter = helpers.utmLetterDesignator(lat);
         utmcoords.hemisphere = lat < 0 ? 'S' : 'N';


### PR DESCRIPTION
I don't know why the variables 'utmEasting' and 'utmNorthing' are rounded. This commit remove the Math.round() function and leave the precision as is.
